### PR TITLE
Create GitHub Action to run specs

### DIFF
--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,6 +1,6 @@
 name: Spec
 
-on: push
+runs-on: push
 
 jobs:
   spec:

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,0 +1,12 @@
+name: Spec
+
+on: push
+
+jobs:
+  spec:
+    name: Run specs
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: oprypin/install-crystal@v1
+      - run: crystal spec

--- a/.github/workflows/spec.yml
+++ b/.github/workflows/spec.yml
@@ -1,10 +1,11 @@
 name: Spec
 
-runs-on: push
+on: push
 
 jobs:
   spec:
     name: Run specs
+    runs-on: ubuntu-latest
 
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -18,13 +18,21 @@ jinxp --help
 
 clone this repo, make a pr
 
+## Build
+
+Install [Crystal and Shards](https://crystal-lang.org/install/), then run:
+
+```
+shards build
+```
+
 ## Contributing
 
-1. Fork it (<https://github.com/elanthia-online/jinx/fork>)
+1. Fork it (<https://github.com/elanthia-online/jinxp/fork>)
 2. Create your feature branch (`git checkout -b my-new-feature`)
 3. Commit your changes (`git commit -am 'Add some feature'`)
 4. Push to the branch (`git push origin my-new-feature`)
-5. Create a new Pull Request
+5. Create a new Pull Request (<https://github.com/elanthia-online/jinxp/compare>)
 
 ## Contributors
 

--- a/spec/jinx_spec.cr
+++ b/spec/jinx_spec.cr
@@ -1,9 +1,0 @@
-require "./spec_helper"
-
-describe Jinx do
-  # TODO: Write tests
-
-  it "works" do
-    false.should eq(true)
-  end
-end


### PR DESCRIPTION
Created my first [GitHub action](https://github.com/elanthia-online/jinxp) to run `crystal spec` on any push in this repo. I got rid of a failing dummy spec that was expecting true to be false since you have some real specs that pass. I also made some small changes to the README that I noticed as I was getting things working locally.