### PR TITLE
Add type attribute to assets

### DIFF
--- a/spec/build_spec.cr
+++ b/spec/build_spec.cr
@@ -17,12 +17,20 @@ describe Jinx::Build do
 
     pp build_2
 
-    build_2.manifest.available.size.should eq 2
+    build_2.manifest.available.size.should eq 3
     noop = build_2.manifest.available.find {|asset|
       asset.file.includes?("noop.lic")
     }
     fail "noop.lic did not compile" unless noop
     noop.tags.size.should eq 3
+    noop.type.should eq "script"
+
+    xml_file = build_2.manifest.available.find {|asset|
+      asset.file.includes?("empty.xml")
+    }
+    fail "empty.xml did not compile" unless xml_file
+    xml_file.tags.should be_empty
+    xml_file.type.should eq "data"
   end
 end
 

--- a/spec/build_spec.cr
+++ b/spec/build_spec.cr
@@ -24,6 +24,7 @@ describe Jinx::Build do
     fail "noop.lic did not compile" unless noop
     noop.tags.size.should eq 3
     noop.type.should eq "script"
+    noop.last_commit.should_not be_nil
 
     xml_file = build_2.manifest.available.find {|asset|
       asset.file.includes?("empty.xml")
@@ -31,6 +32,7 @@ describe Jinx::Build do
     fail "empty.xml did not compile" unless xml_file
     xml_file.tags.should be_empty
     xml_file.type.should eq "data"
+    xml_file.last_commit.should_not be_nil
   end
 end
 

--- a/src/asset.cr
+++ b/src/asset.cr
@@ -7,6 +7,7 @@ module Jinx
     include JSON::Serializable
 
     property file        : String
+    property type        : String
     property md5         : String
     property last_commit : Int32?
     property header      : String?
@@ -23,13 +24,19 @@ module Jinx
 
       File.copy(file, File.join(build.assets, File.basename(file)))
 
-      if File.extname(file) == ".lic"
+      case File.extname(file)
+      when ".lic", ".rb"
+        @type    = "script"
         parser   = headers(build, file, source)
         @tags    = parser.tags
         @header  = parser.file
         @version = parser.version
         @author  = parser.author
+      when ".xml", ".json", ".yml", ".yaml"
+        @type    = "data"
+        @tags = [] of String
       else
+        @type    = "unknown"
         @tags = [] of String
       end
     end

--- a/src/asset.cr
+++ b/src/asset.cr
@@ -32,11 +32,8 @@ module Jinx
         @header  = parser.file
         @version = parser.version
         @author  = parser.author
-      when ".xml", ".json", ".yml", ".yaml"
-        @type    = "data"
-        @tags = [] of String
       else
-        @type    = "unknown"
+        @type    = "data"
         @tags = [] of String
       end
     end

--- a/src/jinx.cr
+++ b/src/jinx.cr
@@ -3,7 +3,7 @@ require "./manifest"
 require "./build"
 # TODO: Write documentation for `Jinx`
 module Jinx
-  VERSION = "0.2.2"
+  VERSION = "0.2.4"
 
   def self.build(input : String, output : String)
     Build.new(input:  File.join(Dir.current, input),


### PR DESCRIPTION
Adds a type attribute to assets based on file type. 

- [X] ~~I'm at the point now where I'd like to deploy my branch and add it as a repo to iterate on the client script, but it looks like [compiling a static binary](https://github.com/crystal-lang/crystal/wiki/Static-Linking) for Netlify with Crystal is complicated. I will probably just stand up something simple local serving my dist dir for now but it seems like your jinxp release works fine on Netlify so hoping you have some insights.~~ [elanthia-online manifest using this version of jinxp](https://5fefa472aabb09000850fd2f--condescending-heyrovsky-08ce0d.netlify.app/manifest.json)
- [X]  ~~I have XML, JSON, and YAML files in the list of recognized data file types. I'm defaulting to "unknown" for unrecognized file types for now but also think defaulting to "data" would be reasonable.~~ Anything that isn't a script is data.
- [X] It feels like the metadata fields would be helpful for data assets too, but I am not sure how to populate them. I am treating the data files as opaque for now, but shouldn't be hard to parse if we want to optimistically check for the metadata fields in them.
