### PR TITLE
Change *.rb files to type "lib"

### DIFF
--- a/src/asset.cr
+++ b/src/asset.cr
@@ -28,14 +28,16 @@ module Jinx
       File.copy(file, File.join(build.assets, File.basename(file)))
 
       case File.extname(file)
-      when ".lic", ".rb"
-        return handle_engine(file) if KNOWN_ENGINES.includes?(File.basename(file))
+      when ".lic"
         @type    = "script"
         parser   = headers(build, file, source)
         @tags    = parser.tags
         @header  = parser.file
         @version = parser.version
         @author  = parser.author
+      when ".rb"
+        return handle_engine(file) if KNOWN_ENGINES.includes?(File.basename(file))
+        @type    = "lib"
       when ".gif", ".jpg", ".png"
         @type    = "map"
       else


### PR DESCRIPTION
This is to enable ruby files outside of the defined engines, to be defined as lib files.  Jinx can then be used to allow the engine update to include library updates based on .rb files.